### PR TITLE
Bump huggingface_hub to support DINOv3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
         if: steps.release-status.outputs.released == 'true'
         run: |
           docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+          VERSION_NO_V="${RELEASE_VERSION#v}"
           docker buildx create --name mybuilder --platform linux/amd64,linux/arm64 --use
-          docker buildx build --no-cache --sbom=true --provenance=true --push --platform linux/amd64,linux/arm64 -t mbari/vss:$RELEASE_VERSION -t mbari/vss:latest --build-arg IMAGE_URI=mbari/vss:$RELEASE_VERSION -f Dockerfile .
-          docker buildx build --no-cache --sbom=true --provenance=true --push --platform linux/amd64 -t mbari/vss:$RELEASE_VERSION-cuda124 --build-arg IMAGE_URI=mbari/vss:$RELEASE_VERSION-cuda124 -f Dockerfile.cuda .
+          docker buildx build --no-cache --sbom=true --provenance=true --push --platform linux/amd64,linux/arm64 -t mbari/vss:$VERSION_NO_V -t mbari/vss:latest --build-arg IMAGE_URI=mbari/vss:$VERSION_NO_V -f Dockerfile .
+          docker buildx build --no-cache --sbom=true --provenance=true --push --platform linux/amd64 -t mbari/vss:$VERSION_NO_V-cuda124 --build-arg IMAGE_URI=mbari/vss:$VERSION_NO_V-cuda124 -f Dockerfile.cuda .

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -20,7 +20,7 @@ RUN grep -vE '^(torch|torchvision)==' src/requirements.txt > /tmp/reqs-no-torch.
     pip install --no-cache-dir -r /tmp/reqs-no-torch.txt && \
     pip install --no-cache-dir https://github.com/redis/redis-py/archive/refs/tags/v5.0.9.zip && \
     pip install --no-cache-dir torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cu130 && \
-    pip install --no-cache-dir huggingface_hub==0.26.0 && \
+    pip install --no-cache-dir huggingface_hub==0.36.2
 
 RUN find /venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; \
     find /venv -type d -name tests -exec rm -rf {} + 2>/dev/null; \

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -9,7 +9,7 @@ services:
     command:
       - /bin/sh
       - -c
-      - redis-stack-server  --port 6379 --appendonly yes --appendfsync everysec --requirepass "$${REDIS_PASSWD:?REDIS_PASSWD variable is not set}"
+      - redis-stack-server  --port 6379 --appendonly yes --appendfsync everysec --auto-aof-rewrite-percentage 200 --no-appendfsync-on-rewrite yes --requirepass "$${REDIS_PASSWD:?REDIS_PASSWD variable is not set}"
     image: redis/redis-stack-server
     container_name: redis-stack-vss-dev
     ports:

--- a/compose.yml
+++ b/compose.yml
@@ -37,7 +37,7 @@ services:
     command:
       - /bin/sh
       - -c
-      - redis-stack-server  --port 6379 --appendonly yes --appendfsync everysec --requirepass "$${REDIS_PASSWD:?REDIS_PASSWD variable is not set}"
+      - redis-stack-server  --port 6379 --appendonly yes --appendfsync everysec --auto-aof-rewrite-percentage 200 --no-appendfsync-on-rewrite yes --requirepass "$${REDIS_PASSWD:?REDIS_PASSWD variable is not set}"
     image: redis/redis-stack-server
     container_name: redis-stack-vss
     ports:

--- a/src/app/predictors/process_vits.py
+++ b/src/app/predictors/process_vits.py
@@ -6,13 +6,15 @@ import os
 import numpy as np
 import redis  # type: ignore
 import torch
-from PIL import Image  # type: ignore
+from PIL import Image, ImageFile  # type: ignore
 from transformers import AutoModel, AutoImageProcessor  # type: ignore
-from typing import List
+from typing import Iterator, List, Tuple
 
 from app.predictors.vector_similarity import VectorSimilarity
 
 import logging
+
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 logging.basicConfig(level=logging.DEBUG)
 debug = logging.debug
@@ -39,14 +41,30 @@ class ViTWrapper:
     def vector_dimensions(self) -> int:
         return self.model.config.hidden_size
 
-    def preprocess_images(self, image_paths: List[str]):
+    def preprocess_images(self, image_paths: List[str]) -> Iterator[Tuple[dict, List[str], List[str]]]:
         debug(f"Preprocessing {len(image_paths)} images")
         for i in range(0, len(image_paths), self.batch_size):
             batch_paths = image_paths[i : i + self.batch_size]
-            images = [Image.open(p).convert("RGB") for p in batch_paths]
+            images = []
+            valid_paths = []
+            failed_paths = []
+            for p in batch_paths:
+                try:
+                    img = Image.open(p)
+                    img.load()
+                    images.append(img.convert("RGB"))
+                    valid_paths.append(p)
+                except Exception as e:
+                    logger.warning(f"Skipping unreadable image {p}: {e}")
+                    failed_paths.append(p)
+            if not images:
+                logger.warning(f"No valid images in batch starting at index {i}, skipping")
+                continue
+            if failed_paths:
+                logger.warning(f"Batch reduced from {len(batch_paths)} to {len(images)} images due to read errors")
             inputs = self.processor(images=images, return_tensors="pt")
-            debug(f"Done preprocessing batch of {len(batch_paths)} images")
-            yield inputs
+            debug(f"Done preprocessing batch of {len(images)} images")
+            yield inputs, valid_paths, failed_paths
 
     def get_image_embeddings(self, inputs):
         """get embeddings for a batch of images"""
@@ -70,7 +88,7 @@ class ViTWrapper:
         ids = []
 
         info(f"Found {len(image_paths)} images to predict")
-        for inputs in self.preprocess_images(image_paths):
+        for inputs, _, _ in self.preprocess_images(image_paths):
             embeddings = self.get_image_embeddings(inputs)
             info(f"Searching for {len(embeddings)} embeddings in Redis")
             for j, emb in enumerate(embeddings):
@@ -90,14 +108,18 @@ class ViTWrapper:
 
         return predictions, scores, ids
 
-    def get_embeddings(self, image_paths: List[str]) -> List[List[float]]:
-        """Get embeddings for a batch of images"""
+    def get_embeddings(self, image_paths: List[str], filenames: List[str] | None = None) -> Tuple[List[List[float]], List[str]]:
+        """Get embeddings for a batch of images. Returns (embeddings, failed_filenames)."""
         all_embeddings = []
+        failed_paths: List[str] = []
+        path_to_filename = dict(zip(image_paths, filenames)) if filenames else {}
 
         info(f"Found {len(image_paths)} images to get embeddings")
-        for inputs in self.preprocess_images(image_paths):
+        for inputs, valid_paths, batch_failed_paths in self.preprocess_images(image_paths):
+            failed_paths.extend(batch_failed_paths)
             embeddings = self.get_image_embeddings(inputs)
             for emb in embeddings:
                 all_embeddings.append(emb.tolist())
 
-        return all_embeddings
+        failed_filenames = [path_to_filename.get(p, p) for p in failed_paths]
+        return all_embeddings, failed_filenames

--- a/src/app/predictors/process_vits.py
+++ b/src/app/predictors/process_vits.py
@@ -2,12 +2,11 @@
 # Filename: predictors/process_vits.py
 # Description: Process images with Vision Transformer (ViT) model and search by KNN embeddings in Redis vector store
 import os
-from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
-import redis
+import redis  # type: ignore
 import torch
-from PIL import Image
+from PIL import Image  # type: ignore
 from transformers import AutoModel, AutoImageProcessor  # type: ignore
 from typing import List
 
@@ -42,13 +41,14 @@ class ViTWrapper:
 
     def preprocess_images(self, image_paths: List[str]):
         debug(f"Preprocessing {len(image_paths)} images")
-        with ThreadPoolExecutor(max_workers=8) as executor:
-            images = list(executor.map(lambda p: Image.open(p).convert("RGB"), image_paths))
-        inputs = self.processor(images=images, return_tensors="pt")
-        debug(f"Done preprocessing {len(image_paths)} images, batch size is {inputs['pixel_values'].shape[0]}")
-        return inputs
+        for i in range(0, len(image_paths), self.batch_size):
+            batch_paths = image_paths[i : i + self.batch_size]
+            images = [Image.open(p).convert("RGB") for p in batch_paths]
+            inputs = self.processor(images=images, return_tensors="pt")
+            debug(f"Done preprocessing batch of {len(batch_paths)} images")
+            yield inputs
 
-    def get_image_embeddings(self, inputs: torch.Tensor):
+    def get_image_embeddings(self, inputs):
         """get embeddings for a batch of images"""
         debug(f"Getting embeddings for batch of size {inputs['pixel_values'].shape[0]}")
         debug(inputs["pixel_values"].shape)  # Should be (B, 3, H, W)
@@ -70,10 +70,8 @@ class ViTWrapper:
         ids = []
 
         info(f"Found {len(image_paths)} images to predict")
-        for i in range(0, len(image_paths), self.batch_size):
-            batch = image_paths[i : i + self.batch_size]
-            images = self.preprocess_images(batch)
-            embeddings = self.get_image_embeddings(images)
+        for inputs in self.preprocess_images(image_paths):
+            embeddings = self.get_image_embeddings(inputs)
             info(f"Searching for {len(embeddings)} embeddings in Redis")
             for j, emb in enumerate(embeddings):
                 r = self.vs.search_vector(emb.tobytes(), top_n=top_n)
@@ -97,10 +95,8 @@ class ViTWrapper:
         all_embeddings = []
 
         info(f"Found {len(image_paths)} images to get embeddings")
-        for i in range(0, len(image_paths), self.batch_size):
-            batch = image_paths[i : i + self.batch_size]
-            images = self.preprocess_images(batch)
-            embeddings = self.get_image_embeddings(images)
+        for inputs in self.preprocess_images(image_paths):
+            embeddings = self.get_image_embeddings(inputs)
             for emb in embeddings:
                 all_embeddings.append(emb.tolist())
 

--- a/src/app/predictors/tasks.py
+++ b/src/app/predictors/tasks.py
@@ -117,12 +117,13 @@ def get_embeddings_task(v_config: dict, image_data: List[bytes], filenames: List
     try:
         logger.info(f"Getting embeddings for {len(temp_paths)} images using model {v_config['model']} on device {v_config['device']}")
         predictor = _predictor_stack.top
-        embeddings = predictor.get_embeddings(temp_paths)
+        embeddings, failed_filenames = predictor.get_embeddings(temp_paths, filenames)
         gc.collect()
 
         output_final = {
             "filenames": filenames,
             "embeddings": embeddings,
+            "failed_filenames": failed_filenames,
         }
         return output_final
     except Exception as e:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -10,7 +10,7 @@ numpy==2.4.2
 async-timeout==5.0.1
 redis==5.0.7
 nvidia-ml-py==13.590.48
-transformers==4.49.0
+transformers==4.57.6
 torch==2.10.0
 torchvision==0.25.0
 rq==2.7.0

--- a/tests/load.py
+++ b/tests/load.py
@@ -25,7 +25,7 @@ v = ViTWrapper(r, device, DEFAULT_MODEL)
 
 for image_path in test_images.glob("*.png"):
     print(f"Processing image: {image_path}")
-    inputs = v.preprocess_images([image_path.as_posix()])
+    inputs, _, _ = next(v.preprocess_images([image_path.as_posix()]))
     emb = v.get_image_embeddings(inputs)
     emb = emb.astype(np.float32)
     print(f"Loaded embedding for {image_path}: {emb.shape} to redis")

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -46,8 +46,10 @@ def test_embed_endpoint():
 
     assert "filenames" in result, f"Missing 'filenames' in result: {result.keys()}"
     assert "embeddings" in result, f"Missing 'embeddings' in result: {result.keys()}"
+    assert "failed_filenames" in result, f"Missing 'failed_filenames' in result: {result.keys()}"
 
     assert result["filenames"] == ["elephant.jpg"], f"Expected filenames ['elephant.jpg'], got {result['filenames']}"
+    assert result["failed_filenames"] == [], f"Expected no failed filenames, got {result['failed_filenames']}"
 
     embeddings = result["embeddings"]
     assert len(embeddings) == 1, f"Expected 1 embedding, got {len(embeddings)}"


### PR DESCRIPTION
## Summary
- Bump `huggingface_hub` so CUDA images can load DINOv3 models (closes #12)
- Improve embedding batching throughput and skip/report corrupt images during processing
- Strip the `v` prefix from release Docker tags for consistent image naming

## Test plan
- [x] Build CUDA image and confirm `huggingface_hub` resolves to the bumped version
- [x] Load a DINOv3 model end-to-end through the embedding path
- [ ] Run embedding against a mix of valid and corrupt images; confirm corrupt filenames are reported and processing continues
- [x] Smoke-test release tag build naming (no leading `v`)


Made with [Cursor](https://cursor.com)