### PR TITLE
fix(ws): keep the job-status socket responsive and bound it by real time

### DIFF
--- a/example.env
+++ b/example.env
@@ -3,6 +3,16 @@ REDIS_PASSWD=xvN2ErdyY4 # Password for Redis, change this to a secure password
 # Optional: comma-separated CORS/WebSocket allowed origins (default includes cortex, doris, mantis, localhost)
 # ALLOWED_ORIGINS=https://cortex.shore.mbari.org,https://mantis.shore.mbari.org
 LOG_LEVEL=INFO
+# WebSocket job-status limits (see ws_job_result in app/main.py).
+# WS_MAX_WAIT: total seconds to wait for a job before closing the connection. Jobs run on a
+#   single serial RQ worker per project, so a job queued behind several others legitimately
+#   waits for all of them; keep this at or above the client's own per-job budget
+#   (fiftyone-sync: FASTVSS_WS_MAX_WAIT).
+# WS_POLL_INTERVAL: seconds between Redis polls, which doubles as the heartbeat interval.
+#   Clients tell a slow job from a dead connection by the gap between frames, so keep this
+#   well below their idle timeout (fiftyone-sync: FASTVSS_WS_IDLE_TIMEOUT, default 120).
+WS_MAX_WAIT=1800
+WS_POLL_INTERVAL=0.5
 GIT_VERSION=latest
 LOG_PATH=/Users/dcline/Dropbox/code/ai/fastapi-vss/logs
 MLDEVOPS_UID=582

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import logging
 import os
+import time
 import warnings
 
 import redis
@@ -73,10 +74,18 @@ if len(config) == 0:
 queues = {}
 connections = {}
 
-# WebSocket poll interval in seconds - short enough to be responsive, avoids hammering Redis
-WS_POLL_INTERVAL = 0.5
-# Maximum time to wait for a job to complete before closing the WebSocket
-WS_MAX_WAIT = 300  # 5 minutes
+# WebSocket poll interval in seconds - short enough to be responsive, avoids hammering Redis.
+# This doubles as the heartbeat interval: a client cannot distinguish a slow job from a dead
+# connection by the job's duration, only by the gap between frames, so it must stay well below
+# whatever idle timeout clients use (fiftyone-sync: FASTVSS_WS_IDLE_TIMEOUT, default 120s).
+WS_POLL_INTERVAL = float(os.getenv("WS_POLL_INTERVAL", "0.5"))
+# Maximum time to wait for a job to complete before closing the WebSocket.
+#
+# Jobs are processed by a single serial RQ worker per project (see start_worker.py), so a job
+# submitted while several others are queued ahead of it legitimately waits for all of them.
+# The old 300s was well under what a backed-up queue needs and cut clients off mid-job. Keep
+# this at or above the client's own per-job budget, or the client's budget is meaningless.
+WS_MAX_WAIT = float(os.getenv("WS_MAX_WAIT", "1800"))
 
 for project in config.keys():
     redis_host = config[project]["redis_host"]
@@ -219,14 +228,19 @@ async def get_job_result(job_id: str, project: str = DEFAULT_PROJECT):
 
     try:
         # Check if the job ID is valid
-        if not Job.exists(job_id, connection=connections[project]):
+        if not await asyncio.to_thread(
+            Job.exists, job_id, connection=connections[project]
+        ):
             return {"error": f"Job ID {job_id} does not exist in project {project}"}
 
         redis_conn = connections[project]
         info(f"Fetching job status for job ID {job_id} in project {project}")
-        job = Job.fetch(job_id, connection=redis_conn)
+        job = await asyncio.to_thread(Job.fetch, job_id, connection=redis_conn)
         if job.is_finished:
-            return {"status": "done", "result": job.return_value()}
+            return {
+                "status": "done",
+                "result": await asyncio.to_thread(job.return_value),
+            }
         elif job.is_failed:
             return {"status": "failed"}
         else:
@@ -252,31 +266,53 @@ async def ws_job_result(websocket: WebSocket, job_id: str, project: str = DEFAUL
 
     redis_conn = connections[project]
 
-    if not Job.exists(job_id, connection=redis_conn):
+    # Job.exists / Job.fetch / job.return_value() are blocking redis-py calls, and this is an
+    # async endpoint sharing one event loop with every other request this process is serving.
+    # Running them inline stalls all of those -- including the heartbeat frames other clients
+    # rely on to tell a slow job from a dead connection -- so they go to a worker thread.
+    # redis-py clients are thread-safe (they hold a connection pool), as is unpickling a
+    # result, which for a batch of embeddings is itself far from free.
+    if not await asyncio.to_thread(Job.exists, job_id, connection=redis_conn):
         await websocket.send_text(json.dumps({"status": "error", "message": f"Job ID {job_id} does not exist in project {project}"}))
         await websocket.close()
         return
 
-    elapsed = 0.0
+    # Wall-clock, not a count of loop iterations. Incrementing a counter by WS_POLL_INTERVAL
+    # (as this used to) measures only the sleeps and ignores how long each Redis round-trip
+    # took, so the effective limit drifted arbitrarily far past WS_MAX_WAIT under load --
+    # exactly when an accurate limit matters.
+    start = time.monotonic()
     try:
-        while elapsed < WS_MAX_WAIT:
-            job = Job.fetch(job_id, connection=redis_conn)
+        while True:
+            elapsed = time.monotonic() - start
+            if elapsed >= WS_MAX_WAIT:
+                info(f"WebSocket job {job_id} timed out in project {project} after {elapsed:.0f}s")
+                await websocket.send_text(json.dumps({
+                    "status": "error",
+                    "message": f"Timed out waiting for job after {elapsed:.0f}s",
+                }))
+                break
+
+            job = await asyncio.to_thread(Job.fetch, job_id, connection=redis_conn)
 
             if job.is_finished:
-                info(f"WebSocket job {job_id} finished in project {project}")
-                await websocket.send_text(json.dumps({"status": "done", "result": job.return_value()}))
+                info(f"WebSocket job {job_id} finished in project {project} after {elapsed:.0f}s")
+                result = await asyncio.to_thread(job.return_value)
+                await websocket.send_text(json.dumps({"status": "done", "result": result}))
                 break
             elif job.is_failed:
-                info(f"WebSocket job {job_id} failed in project {project}")
-                await websocket.send_text(json.dumps({"status": "failed"}))
+                info(f"WebSocket job {job_id} failed in project {project} after {elapsed:.0f}s")
+                await websocket.send_text(json.dumps({
+                    "status": "failed",
+                    "message": f"Job {job_id} failed in project {project}",
+                }))
                 break
             else:
+                # Heartbeat. Clients time out on the gap between frames, so this must keep
+                # flowing for the whole wait, however long the job itself takes.
                 await websocket.send_text(json.dumps({"status": "pending"}))
 
             await asyncio.sleep(WS_POLL_INTERVAL)
-            elapsed += WS_POLL_INTERVAL
-        else:
-            await websocket.send_text(json.dumps({"status": "error", "message": "Timed out waiting for job"}))
     except WebSocketDisconnect:
         debug(f"WebSocket client disconnected for job {job_id} in project {project}")
     except Exception as e:

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -2,6 +2,8 @@
 # Filename: tests/test_websocket.py
 # Description: Tests for WebSocket job status endpoint
 import json
+import threading
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -70,6 +72,7 @@ class TestWebSocketJobResult:
             with client.websocket_connect("/ws/predict/job/failed-id/testproject") as ws:
                 msg = json.loads(ws.receive_text())
         assert msg["status"] == "failed"
+        assert "failed-id" in msg["message"]
 
     def test_job_pending_then_done(self, client):
         """Job starts pending, then becomes finished on the second poll."""
@@ -130,6 +133,96 @@ class TestWebSocketJobResult:
         assert messages[2]["status"] == "pending"
         assert messages[3]["status"] == "done"
         assert messages[3]["result"] == {"predictions": [["A", "B"]]}
+
+
+class TestWebSocketTimeoutIsWallClock:
+    """WS_MAX_WAIT must be a real elapsed-time limit, not a count of loop iterations."""
+
+    def test_timeout_message_reports_elapsed_seconds(self, client):
+        pending_job = _make_job(finished=False, failed=False)
+
+        with (
+            patch("app.main.Job.exists", return_value=True),
+            patch("app.main.Job.fetch", return_value=pending_job),
+            patch("app.main.WS_MAX_WAIT", 0),  # expire on the first check
+        ):
+            with client.websocket_connect("/ws/predict/job/slow-id/testproject") as ws:
+                msg = json.loads(ws.receive_text())
+
+        assert msg["status"] == "error"
+        assert "Timed out waiting for job after" in msg["message"]
+
+    def test_slow_redis_still_counts_against_the_budget(self, client):
+        """
+        Regression test for tracking elapsed time as `elapsed += WS_POLL_INTERVAL`.
+
+        That counted sleeps only and ignored how long each Redis round-trip took, so with a
+        slow Redis (exactly when a bound matters) the real limit drifted arbitrarily far past
+        WS_MAX_WAIT -- and with WS_POLL_INTERVAL patched to 0, as below, it never advanced at
+        all and the loop ran forever.
+        """
+        pending_job = _make_job(finished=False, failed=False)
+
+        def slow_fetch(*args, **kwargs):
+            time.sleep(0.15)
+            return pending_job
+
+        with (
+            patch("app.main.Job.exists", return_value=True),
+            patch("app.main.Job.fetch", side_effect=slow_fetch),
+            patch("app.main.WS_POLL_INTERVAL", 0),
+            patch("app.main.WS_MAX_WAIT", 0.2),
+        ):
+            with client.websocket_connect("/ws/predict/job/slow-redis/testproject") as ws:
+                statuses = []
+                for _ in range(50):  # bounded so a regression fails rather than hangs
+                    statuses.append(json.loads(ws.receive_text())["status"])
+                    if statuses[-1] != "pending":
+                        break
+
+        assert statuses[-1] == "error", f"never timed out; got {len(statuses)} frames"
+
+
+class TestBlockingRedisCallsRunOffTheEventLoop:
+    """
+    Job.exists / Job.fetch / job.return_value() are blocking redis-py calls.
+
+    Running them directly in the async endpoint stalls the single event loop shared by every
+    other connection this process serves -- including the heartbeat frames those clients use
+    to distinguish a slow job from a dead connection. They must be dispatched to a thread.
+    """
+
+    def test_job_calls_are_dispatched_to_a_worker_thread(self, client):
+        seen = {}
+        finished_job = MagicMock()
+        finished_job.is_finished = True
+        finished_job.is_failed = False
+
+        def record(name, result):
+            def _inner(*args, **kwargs):
+                seen[name] = threading.current_thread().name
+                return result
+
+            return _inner
+
+        finished_job.return_value = record("return_value", {"embeddings": [[0.5]]})
+
+        with (
+            patch("app.main.Job.exists", side_effect=record("exists", True)),
+            patch("app.main.Job.fetch", side_effect=record("fetch", finished_job)),
+        ):
+            with client.websocket_connect("/ws/predict/job/thread-id/testproject") as ws:
+                msg = json.loads(ws.receive_text())
+
+        assert msg["status"] == "done"
+        assert msg["result"] == {"embeddings": [[0.5]]}
+        # asyncio.to_thread runs work on the default executor, whose threads are named
+        # "asyncio_N". Anything left inline would report the event loop's own thread.
+        for name in ("exists", "fetch", "return_value"):
+            assert name in seen, f"{name} was never called"
+            assert seen[name].startswith("asyncio_"), (
+                f"{name} ran on {seen[name]!r}, i.e. inline on the event loop"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Move blocking Redis calls (`Job.exists`, `Job.fetch`, `job.return_value`) off the async event loop via `asyncio.to_thread`, so heartbeat frames keep flowing to other WebSocket clients while a job is polled.
- Replace iteration-based timeout tracking with wall-clock elapsed time (`time.monotonic`), fixing cases where slow Redis round-trips pushed the effective limit far past `WS_MAX_WAIT`.
- Raise the default `WS_MAX_WAIT` from 300s to 1800s and make both `WS_MAX_WAIT` and `WS_POLL_INTERVAL` configurable via environment variables; document the settings in `example.env`.
- Add regression tests for wall-clock timeout behavior and thread dispatch of Redis calls.