### PR TITLE
perf(vits): cut per-batch preprocessing from seconds to a fraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 
 
+## v0.16.2 (2026-08-25)
+
+### Fix
+
+* fix(ws): keep the job-status socket responsive and bound it by real time (#15)
+
+Clients embedding a dataset through /embed + /ws/predict/job saw bursts of
+inter-frame timeouts as soon as more than a couple of batches were in flight.
+Two defects on this side contributed.
+
+1. Blocking Redis calls ran inline on the event loop.
+   Job.exists, Job.fetch and job.return_value() are synchronous redis-py calls,
+   and ws_job_result is an async endpoint sharing one event loop with every
+   other connection this process serves. Under N concurrent job sockets each
+   polling at 1/WS_POLL_INTERVAL, plus concurrent multipart uploads, the loop
+   spent its time inside Redis round-trips and unpickling embedding payloads --
+   delaying the very heartbeat frames clients use to distinguish a slow job
+   from a dead connection, and so causing the timeouts it was meant to prevent.
+   All three now go through asyncio.to_thread; redis-py clients are thread-safe
+   (they hold a connection pool), as is unpickling a result.
+
+2. WS_MAX_WAIT counted loop iterations, not elapsed time.
+   `elapsed += WS_POLL_INTERVAL` measured only the sleeps and ignored how long
+   each Redis round-trip took, so the effective limit drifted arbitrarily far
+   past WS_MAX_WAIT under load -- exactly when a real bound matters. It is now
+   a time.monotonic() deadline, and the timeout frame reports how long it
+   actually waited.
+
+WS_MAX_WAIT and WS_POLL_INTERVAL are now environment-configurable, and the
+default wait is raised from 300s to 1800s: jobs are processed by a single
+serial RQ worker per project, so a job submitted while several others are
+queued ahead of it legitimately waits for all of them, and 300s cut clients off
+mid-job. A failed job now names itself in the message instead of sending a bare
+{&#34;status&#34;: &#34;failed&#34;}.
+
+Note this does not raise throughput -- one worker per project still processes
+jobs serially, so client-side concurrency only queues them faster. Scaling the
+rq-worker service is the lever for that.
+
+
+Claude-Session: https://claude.ai/code/session_019s65VkcHwERBZrXXpaivVy
+
+Co-authored-by: Claude &lt;noreply@anthropic.com&gt; ([`604ae20`](https://github.com/mbari-org/vss/commit/604ae202cf6753df4fc187fd7c424508e5a363cc))
+
+
 ## v0.16.1 (2026-07-17)
 
 ### Performance

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,6 +1,8 @@
 # ================================================================
 #  Docker image for fastapi-vss (CUDA 13, deploy: multi-stage + non-root)
 # ================================================================
+ARG GIT_VERSION=latest
+
 FROM nvidia/cuda:13.0.1-runtime-ubuntu22.04 AS builder
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
@@ -59,12 +61,11 @@ RUN find /venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; \
 # installed below.
 FROM nvidia/cuda:13.0.1-base-ubuntu22.04
 ENV DEBIAN_FRONTEND=noninteractive
+ARG GIT_VERSION=latest
 LABEL vendor="MBARI"
 LABEL maintainer="dcline@mbari.org"
 LABEL license="Apache License 2.0"
-
-ARG UID=1001
-ARG GID=1001
+LABEL org.opencontainers.image.version="${GIT_VERSION}"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common && \
@@ -75,9 +76,6 @@ RUN apt-get update && \
         gcc g++ \
         curl libxcb1 libxcb-xinerama0 libxrender1 libxext6 libsm6 libice6 libgl1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
-
-RUN groupadd --gid ${GID} appuser && \
-    useradd --uid ${UID} --gid ${GID} --no-create-home appuser
 
 ENV PATH="/venv/bin:$PATH"
 ENV APP_HOME=/app
@@ -94,7 +92,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 # which raises KeyError on an unknown uid. Setting USER/HOME makes getpass short-
 # circuit on the env var, and routing torch/HF caches to world-writable /tmp keeps
 # them writable for any uid (needed for the optional VSS_TORCH_COMPILE path).
-ENV USER=appuser
+ENV USER=mldevops
 ENV HOME=/tmp
 ENV XDG_CACHE_HOME=/tmp/.cache
 ENV TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor
@@ -104,9 +102,13 @@ WORKDIR $APP_HOME
 COPY --from=builder /venv /venv
 COPY . .
 
-RUN chown -R appuser:appuser /app /venv
+# Match MBARI host user mldevops (uid 12078, gid 20)
+RUN (getent group 20 || groupadd -g 20 appgroup) && \
+    useradd -u 12078 -g 20 -m -s /bin/bash mldevops && \
+    mkdir -p /tmp/transformers_cache /tmp/logs && \
+    chown -R mldevops:20 $APP_HOME /venv /tmp/transformers_cache /tmp/logs
 
-USER ${UID}:${GID}
+USER mldevops
 
 ARG NUM_WORKERS=1
 ENV NUM_WORKERS=${NUM_WORKERS}

--- a/example.env
+++ b/example.env
@@ -3,6 +3,16 @@ REDIS_PASSWD=xvN2ErdyY4 # Password for Redis, change this to a secure password
 # Optional: comma-separated CORS/WebSocket allowed origins (default includes cortex, doris, mantis, localhost)
 # ALLOWED_ORIGINS=https://cortex.shore.mbari.org,https://mantis.shore.mbari.org
 LOG_LEVEL=INFO
+# WebSocket job-status limits (see ws_job_result in app/main.py).
+# WS_MAX_WAIT: total seconds to wait for a job before closing the connection. Jobs run on a
+#   single serial RQ worker per project, so a job queued behind several others legitimately
+#   waits for all of them; keep this at or above the client's own per-job budget
+#   (fiftyone-sync: FASTVSS_WS_MAX_WAIT).
+# WS_POLL_INTERVAL: seconds between Redis polls, which doubles as the heartbeat interval.
+#   Clients tell a slow job from a dead connection by the gap between frames, so keep this
+#   well below their idle timeout (fiftyone-sync: FASTVSS_WS_IDLE_TIMEOUT, default 120).
+WS_MAX_WAIT=1800
+WS_POLL_INTERVAL=0.5
 GIT_VERSION=latest
 LOG_PATH=/Users/dcline/Dropbox/code/ai/fastapi-vss/logs
 MLDEVOPS_UID=582

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,2 +1,2 @@
 # src/app/__init__.py
-__version__ = "0.16.1"
+__version__ = "0.16.2"

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import logging
 import os
+import time
 import warnings
 
 import redis
@@ -73,10 +74,18 @@ if len(config) == 0:
 queues = {}
 connections = {}
 
-# WebSocket poll interval in seconds - short enough to be responsive, avoids hammering Redis
-WS_POLL_INTERVAL = 0.5
-# Maximum time to wait for a job to complete before closing the WebSocket
-WS_MAX_WAIT = 300  # 5 minutes
+# WebSocket poll interval in seconds - short enough to be responsive, avoids hammering Redis.
+# This doubles as the heartbeat interval: a client cannot distinguish a slow job from a dead
+# connection by the job's duration, only by the gap between frames, so it must stay well below
+# whatever idle timeout clients use (fiftyone-sync: FASTVSS_WS_IDLE_TIMEOUT, default 120s).
+WS_POLL_INTERVAL = float(os.getenv("WS_POLL_INTERVAL", "0.5"))
+# Maximum time to wait for a job to complete before closing the WebSocket.
+#
+# Jobs are processed by a single serial RQ worker per project (see start_worker.py), so a job
+# submitted while several others are queued ahead of it legitimately waits for all of them.
+# The old 300s was well under what a backed-up queue needs and cut clients off mid-job. Keep
+# this at or above the client's own per-job budget, or the client's budget is meaningless.
+WS_MAX_WAIT = float(os.getenv("WS_MAX_WAIT", "1800"))
 
 for project in config.keys():
     redis_host = config[project]["redis_host"]
@@ -219,14 +228,19 @@ async def get_job_result(job_id: str, project: str = DEFAULT_PROJECT):
 
     try:
         # Check if the job ID is valid
-        if not Job.exists(job_id, connection=connections[project]):
+        if not await asyncio.to_thread(
+            Job.exists, job_id, connection=connections[project]
+        ):
             return {"error": f"Job ID {job_id} does not exist in project {project}"}
 
         redis_conn = connections[project]
         info(f"Fetching job status for job ID {job_id} in project {project}")
-        job = Job.fetch(job_id, connection=redis_conn)
+        job = await asyncio.to_thread(Job.fetch, job_id, connection=redis_conn)
         if job.is_finished:
-            return {"status": "done", "result": job.return_value()}
+            return {
+                "status": "done",
+                "result": await asyncio.to_thread(job.return_value),
+            }
         elif job.is_failed:
             return {"status": "failed"}
         else:
@@ -252,31 +266,53 @@ async def ws_job_result(websocket: WebSocket, job_id: str, project: str = DEFAUL
 
     redis_conn = connections[project]
 
-    if not Job.exists(job_id, connection=redis_conn):
+    # Job.exists / Job.fetch / job.return_value() are blocking redis-py calls, and this is an
+    # async endpoint sharing one event loop with every other request this process is serving.
+    # Running them inline stalls all of those -- including the heartbeat frames other clients
+    # rely on to tell a slow job from a dead connection -- so they go to a worker thread.
+    # redis-py clients are thread-safe (they hold a connection pool), as is unpickling a
+    # result, which for a batch of embeddings is itself far from free.
+    if not await asyncio.to_thread(Job.exists, job_id, connection=redis_conn):
         await websocket.send_text(json.dumps({"status": "error", "message": f"Job ID {job_id} does not exist in project {project}"}))
         await websocket.close()
         return
 
-    elapsed = 0.0
+    # Wall-clock, not a count of loop iterations. Incrementing a counter by WS_POLL_INTERVAL
+    # (as this used to) measures only the sleeps and ignores how long each Redis round-trip
+    # took, so the effective limit drifted arbitrarily far past WS_MAX_WAIT under load --
+    # exactly when an accurate limit matters.
+    start = time.monotonic()
     try:
-        while elapsed < WS_MAX_WAIT:
-            job = Job.fetch(job_id, connection=redis_conn)
+        while True:
+            elapsed = time.monotonic() - start
+            if elapsed >= WS_MAX_WAIT:
+                info(f"WebSocket job {job_id} timed out in project {project} after {elapsed:.0f}s")
+                await websocket.send_text(json.dumps({
+                    "status": "error",
+                    "message": f"Timed out waiting for job after {elapsed:.0f}s",
+                }))
+                break
+
+            job = await asyncio.to_thread(Job.fetch, job_id, connection=redis_conn)
 
             if job.is_finished:
-                info(f"WebSocket job {job_id} finished in project {project}")
-                await websocket.send_text(json.dumps({"status": "done", "result": job.return_value()}))
+                info(f"WebSocket job {job_id} finished in project {project} after {elapsed:.0f}s")
+                result = await asyncio.to_thread(job.return_value)
+                await websocket.send_text(json.dumps({"status": "done", "result": result}))
                 break
             elif job.is_failed:
-                info(f"WebSocket job {job_id} failed in project {project}")
-                await websocket.send_text(json.dumps({"status": "failed"}))
+                info(f"WebSocket job {job_id} failed in project {project} after {elapsed:.0f}s")
+                await websocket.send_text(json.dumps({
+                    "status": "failed",
+                    "message": f"Job {job_id} failed in project {project}",
+                }))
                 break
             else:
+                # Heartbeat. Clients time out on the gap between frames, so this must keep
+                # flowing for the whole wait, however long the job itself takes.
                 await websocket.send_text(json.dumps({"status": "pending"}))
 
             await asyncio.sleep(WS_POLL_INTERVAL)
-            elapsed += WS_POLL_INTERVAL
-        else:
-            await websocket.send_text(json.dumps({"status": "error", "message": "Timed out waiting for job"}))
     except WebSocketDisconnect:
         debug(f"WebSocket client disconnected for job {job_id} in project {project}")
     except Exception as e:

--- a/src/app/predictors/process_vits.py
+++ b/src/app/predictors/process_vits.py
@@ -1,14 +1,16 @@
 # fastapi-vss, Apache-2.0 license
 # Filename: predictors/process_vits.py
 # Description: Process images with Vision Transformer (ViT) model and search by KNN embeddings in Redis vector store
+import io
 import os
+from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 import redis  # type: ignore
 import torch
 from PIL import Image, ImageFile  # type: ignore
 from transformers import AutoModel, AutoImageProcessor  # type: ignore
-from typing import Iterator, List, Tuple
+from typing import Iterator, List, Optional, Tuple, Union
 
 from app.predictors.vector_similarity import VectorSimilarity
 
@@ -25,12 +27,62 @@ logger = logging.getLogger(__name__)
 logger.addHandler(console)
 
 
+# An image to embed: a filesystem path, or an in-memory buffer of encoded bytes.
+ImageSource = Union[str, bytes, io.BytesIO]
+
+
+def _default_decode_workers() -> int:
+    """Threads used to decode one batch (VSS_DECODE_WORKERS, default min(8, cpu count))."""
+    raw = os.getenv("VSS_DECODE_WORKERS", "").strip()
+    if raw:
+        try:
+            return max(1, int(raw))
+        except ValueError:
+            logger.warning(f"Ignoring invalid VSS_DECODE_WORKERS={raw!r}")
+    return max(1, min(8, os.cpu_count() or 1))
+
+
+def _open_rgb(source: ImageSource) -> Image.Image:
+    """Decode one image from a path or an in-memory buffer into RGB."""
+    if isinstance(source, (bytes, bytearray)):
+        source = io.BytesIO(source)
+    elif isinstance(source, io.IOBase):
+        source.seek(0)
+    img = Image.open(source)
+    # Force the decode here rather than lazily later: this call is what the thread pool is
+    # parallelizing, and PIL releases the GIL inside it.
+    img.load()
+    return img.convert("RGB")
+
+
 class ViTWrapper:
     def __init__(self, r: redis.Redis, device, model_name: str, reset: bool = False, batch_size: int = 32):
         self.r = r
         self.device = torch.device(device) if not isinstance(device, torch.device) else device
         self.batch_size = batch_size
-        self.processor = AutoImageProcessor.from_pretrained(model_name)
+        # transformers resolves a *slow* image processor when `use_fast` is unset, unless the
+        # checkpoint was saved with a fast one -- in 4.57 only Qwen2VL is force-upgraded
+        # (FORCE_FAST_IMAGE_PROCESSOR). The slow path resizes, rescales and normalizes one
+        # image at a time in Python/NumPy on the CPU, and it dominated batch latency: seconds
+        # per batch of 128 crops, all of it with the GPU idle. The torchvision-backed fast
+        # processor does the same work batched.
+        #
+        # Fast output differs very slightly (torchvision resize vs PIL), so embeddings shift
+        # a little; set VSS_FAST_PROCESSOR=0 to keep the old behaviour when querying a Redis
+        # index that was built with the slow processor.
+        want_fast = os.getenv("VSS_FAST_PROCESSOR", "1") == "1"
+        try:
+            self.processor = AutoImageProcessor.from_pretrained(model_name, use_fast=want_fast)
+        except Exception as e:
+            logger.warning(
+                f"Could not load image processor with use_fast={want_fast} ({e}); "
+                "falling back to the default processor"
+            )
+            self.processor = AutoImageProcessor.from_pretrained(model_name)
+        info(f"Image processor: {type(self.processor).__name__} (requested use_fast={want_fast})")
+
+        self.decode_workers = _default_decode_workers()
+        info(f"Image decode threads: {self.decode_workers}")
         self.model = AutoModel.from_pretrained(model_name).to(self.device)
         # eval() disables dropout and puts the model in inference mode
         self.model.eval()
@@ -62,30 +114,61 @@ class ViTWrapper:
     def vector_dimensions(self) -> int:
         return self.model.config.hidden_size
 
-    def preprocess_images(self, image_paths: List[str]) -> Iterator[Tuple[dict, List[str], List[str]]]:
-        debug(f"Preprocessing {len(image_paths)} images")
-        for i in range(0, len(image_paths), self.batch_size):
-            batch_paths = image_paths[i : i + self.batch_size]
+    def preprocess_images(
+        self,
+        image_sources: List[ImageSource],
+        labels: Optional[List[str]] = None,
+    ) -> Iterator[Tuple[dict, List[str], List[str]]]:
+        """
+        Decode images and run the processor, yielding one model-ready batch at a time.
+
+        `image_sources` may be filesystem paths or in-memory buffers of encoded bytes.
+        `labels` names each source for logging and for the failed-image report; it defaults
+        to the source itself, so passing a list of paths behaves exactly as before.
+
+        Yields (inputs, valid_labels, failed_labels).
+        """
+        debug(f"Preprocessing {len(image_sources)} images")
+        names = list(labels) if labels else [str(s) for s in image_sources]
+
+        def _safe_open(item: Tuple[ImageSource, str]) -> Optional[Image.Image]:
+            source, name = item
+            try:
+                return _open_rgb(source)
+            except Exception as e:
+                logger.warning(f"Skipping unreadable image {name}: {e}")
+                return None
+
+        for i in range(0, len(image_sources), self.batch_size):
+            batch = image_sources[i : i + self.batch_size]
+            batch_names = names[i : i + self.batch_size]
+
+            # Decode on a thread pool. PIL releases the GIL inside load(), so this scales
+            # with cores; done serially it cost seconds per batch of large crops, with the
+            # GPU sitting idle throughout. pool.map preserves order, which matters because
+            # embeddings are matched back to their inputs positionally.
+            workers = max(1, min(self.decode_workers, len(batch)))
+            with ThreadPoolExecutor(max_workers=workers) as pool:
+                decoded = list(pool.map(_safe_open, zip(batch, batch_names)))
+
             images = []
-            valid_paths = []
-            failed_paths = []
-            for p in batch_paths:
-                try:
-                    img = Image.open(p)
-                    img.load()
-                    images.append(img.convert("RGB"))
-                    valid_paths.append(p)
-                except Exception as e:
-                    logger.warning(f"Skipping unreadable image {p}: {e}")
-                    failed_paths.append(p)
+            valid_labels: List[str] = []
+            failed_labels: List[str] = []
+            for name, img in zip(batch_names, decoded):
+                if img is None:
+                    failed_labels.append(name)
+                else:
+                    images.append(img)
+                    valid_labels.append(name)
+
             if not images:
                 logger.warning(f"No valid images in batch starting at index {i}, skipping")
                 continue
-            if failed_paths:
-                logger.warning(f"Batch reduced from {len(batch_paths)} to {len(images)} images due to read errors")
+            if failed_labels:
+                logger.warning(f"Batch reduced from {len(batch)} to {len(images)} images due to read errors")
             inputs = self.processor(images=images, return_tensors="pt")
             debug(f"Done preprocessing batch of {len(images)} images")
-            yield inputs, valid_paths, failed_paths
+            yield inputs, valid_labels, failed_labels
 
     def _forward(self, inputs):
         """Run the model forward pass under inference_mode and optional fp16 autocast."""
@@ -122,7 +205,7 @@ class ViTWrapper:
         info(f"Batch embeddings shape: {batch_embeddings.shape}")
         return np.array(batch_embeddings)
 
-    def predict(self, image_paths: List[str], top_n: int = 1) -> tuple[list[list[str]], list[list[float]], list[list[str]]]:
+    def predict(self, image_paths: List[ImageSource], top_n: int = 1) -> tuple[list[list[str]], list[list[float]], list[list[str]]]:
         """Search using KNN for embeddings for a batch of images"""
         predictions = []
         scores = []
@@ -151,18 +234,18 @@ class ViTWrapper:
 
         return predictions, scores, ids
 
-    def get_embeddings(self, image_paths: List[str], filenames: List[str] | None = None) -> Tuple[List[List[float]], List[str]]:
+    def get_embeddings(self, image_sources: List[ImageSource], filenames: List[str] | None = None) -> Tuple[List[List[float]], List[str]]:
         """Get embeddings for a batch of images. Returns (embeddings, failed_filenames)."""
         all_embeddings = []
-        failed_paths: List[str] = []
-        path_to_filename = dict(zip(image_paths, filenames)) if filenames else {}
+        failed_filenames: List[str] = []
 
-        info(f"Found {len(image_paths)} images to get embeddings")
-        for inputs, valid_paths, batch_failed_paths in self.preprocess_images(image_paths):
-            failed_paths.extend(batch_failed_paths)
+        info(f"Found {len(image_sources)} images to get embeddings")
+        # Labels are the caller's filenames, so failures come back named without having to
+        # key a dict on the sources themselves (which may be anonymous in-memory buffers).
+        for inputs, _, batch_failed in self.preprocess_images(image_sources, labels=filenames):
+            failed_filenames.extend(batch_failed)
             embeddings = self.get_image_embeddings(inputs)
             for emb in embeddings:
                 all_embeddings.append(emb.tolist())
 
-        failed_filenames = [path_to_filename.get(p, p) for p in failed_paths]
         return all_embeddings, failed_filenames

--- a/src/app/predictors/tasks.py
+++ b/src/app/predictors/tasks.py
@@ -2,10 +2,10 @@
 # Filename: predictors/tasks.py
 # Description: Worker task file for processing images with Vision Transformer (ViT) models
 import gc
+import io
 import json
 import logging
 import os
-import tempfile
 import time
 import traceback
 from datetime import datetime
@@ -51,31 +51,32 @@ class MyWorker(SimpleWorker):
         return super().work(burst, logging_level)
 
 
-def _bytes_to_temp_paths(image_data: List[bytes], filenames: List[str]) -> List[str]:
-    """Write image bytes to temp files and return their paths. Caller must unlink paths when done."""
-    paths = []
-    for data, name in zip(image_data, filenames):
-        suffix = Path(name).suffix or ".png"
-        fd, path = tempfile.mkstemp(suffix=suffix)
-        try:
-            if hasattr(data, "read"):
-                data.seek(0)
-                raw = data.read()
-            else:
-                raw = data
-            os.write(fd, raw)
-        finally:
-            os.close(fd)
-        paths.append(path)
-    return paths
+def _to_image_buffers(image_data: List[bytes]) -> List[io.BytesIO]:
+    """
+    Wrap uploaded image bytes in in-memory buffers for the predictor.
+
+    These bytes arrive from the HTTP upload already in memory. The previous version wrote
+    every one of them to a temp file so PIL could read it straight back off disk, costing a
+    full write + read cycle per batch (seconds, for large crops) and leaving temp files to
+    unlink afterwards.
+    """
+    buffers = []
+    for data in image_data:
+        if hasattr(data, "read"):
+            data.seek(0)
+            raw = data.read()
+        else:
+            raw = data
+        buffers.append(io.BytesIO(raw))
+    return buffers
 
 
 def predict_on_cpu_or_gpu(v_config: dict, image_data: List[bytes], top_n: int, filenames: List[str]) -> dict:
-    temp_paths = _bytes_to_temp_paths(image_data, filenames)
+    buffers = _to_image_buffers(image_data)
     try:
-        logger.info(f"Predicting on {len(temp_paths)} images with top_n={top_n} using model {v_config['model']} on device {v_config['device']}")
+        logger.info(f"Predicting on {len(buffers)} images with top_n={top_n} using model {v_config['model']} on device {v_config['device']}")
         predictor = _predictor_stack.top
-        predictions, scores, ids = predictor.predict(temp_paths, top_n)
+        predictions, scores, ids = predictor.predict(buffers, top_n)
         gc.collect()
 
         # Use the current date and time (hourly granularity) for output directory and time with nanoseconds for the filename to ensure uniqueness
@@ -104,20 +105,14 @@ def predict_on_cpu_or_gpu(v_config: dict, image_data: List[bytes], top_n: int, f
         error_message = f"Error during prediction: {e}\n{traceback.format_exc()}"
         logger.info(error_message)
         return error_message
-    finally:
-        for p in temp_paths:
-            try:
-                os.unlink(p)
-            except OSError:
-                pass
 
 
 def get_embeddings_task(v_config: dict, image_data: List[bytes], filenames: List[str]) -> dict:
-    temp_paths = _bytes_to_temp_paths(image_data, filenames)
+    buffers = _to_image_buffers(image_data)
     try:
-        logger.info(f"Getting embeddings for {len(temp_paths)} images using model {v_config['model']} on device {v_config['device']}")
+        logger.info(f"Getting embeddings for {len(buffers)} images using model {v_config['model']} on device {v_config['device']}")
         predictor = _predictor_stack.top
-        embeddings, failed_filenames = predictor.get_embeddings(temp_paths, filenames)
+        embeddings, failed_filenames = predictor.get_embeddings(buffers, filenames)
         gc.collect()
 
         output_final = {
@@ -130,9 +125,4 @@ def get_embeddings_task(v_config: dict, image_data: List[bytes], filenames: List
         error_message = f"Error during embedding generation: {e}\n{traceback.format_exc()}"
         logger.info(error_message)
         return error_message
-    finally:
-        for p in temp_paths:
-            try:
-                os.unlink(p)
-            except OSError:
-                pass
+

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -2,6 +2,8 @@
 # Filename: tests/test_websocket.py
 # Description: Tests for WebSocket job status endpoint
 import json
+import threading
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -70,6 +72,7 @@ class TestWebSocketJobResult:
             with client.websocket_connect("/ws/predict/job/failed-id/testproject") as ws:
                 msg = json.loads(ws.receive_text())
         assert msg["status"] == "failed"
+        assert "failed-id" in msg["message"]
 
     def test_job_pending_then_done(self, client):
         """Job starts pending, then becomes finished on the second poll."""
@@ -130,6 +133,96 @@ class TestWebSocketJobResult:
         assert messages[2]["status"] == "pending"
         assert messages[3]["status"] == "done"
         assert messages[3]["result"] == {"predictions": [["A", "B"]]}
+
+
+class TestWebSocketTimeoutIsWallClock:
+    """WS_MAX_WAIT must be a real elapsed-time limit, not a count of loop iterations."""
+
+    def test_timeout_message_reports_elapsed_seconds(self, client):
+        pending_job = _make_job(finished=False, failed=False)
+
+        with (
+            patch("app.main.Job.exists", return_value=True),
+            patch("app.main.Job.fetch", return_value=pending_job),
+            patch("app.main.WS_MAX_WAIT", 0),  # expire on the first check
+        ):
+            with client.websocket_connect("/ws/predict/job/slow-id/testproject") as ws:
+                msg = json.loads(ws.receive_text())
+
+        assert msg["status"] == "error"
+        assert "Timed out waiting for job after" in msg["message"]
+
+    def test_slow_redis_still_counts_against_the_budget(self, client):
+        """
+        Regression test for tracking elapsed time as `elapsed += WS_POLL_INTERVAL`.
+
+        That counted sleeps only and ignored how long each Redis round-trip took, so with a
+        slow Redis (exactly when a bound matters) the real limit drifted arbitrarily far past
+        WS_MAX_WAIT -- and with WS_POLL_INTERVAL patched to 0, as below, it never advanced at
+        all and the loop ran forever.
+        """
+        pending_job = _make_job(finished=False, failed=False)
+
+        def slow_fetch(*args, **kwargs):
+            time.sleep(0.15)
+            return pending_job
+
+        with (
+            patch("app.main.Job.exists", return_value=True),
+            patch("app.main.Job.fetch", side_effect=slow_fetch),
+            patch("app.main.WS_POLL_INTERVAL", 0),
+            patch("app.main.WS_MAX_WAIT", 0.2),
+        ):
+            with client.websocket_connect("/ws/predict/job/slow-redis/testproject") as ws:
+                statuses = []
+                for _ in range(50):  # bounded so a regression fails rather than hangs
+                    statuses.append(json.loads(ws.receive_text())["status"])
+                    if statuses[-1] != "pending":
+                        break
+
+        assert statuses[-1] == "error", f"never timed out; got {len(statuses)} frames"
+
+
+class TestBlockingRedisCallsRunOffTheEventLoop:
+    """
+    Job.exists / Job.fetch / job.return_value() are blocking redis-py calls.
+
+    Running them directly in the async endpoint stalls the single event loop shared by every
+    other connection this process serves -- including the heartbeat frames those clients use
+    to distinguish a slow job from a dead connection. They must be dispatched to a thread.
+    """
+
+    def test_job_calls_are_dispatched_to_a_worker_thread(self, client):
+        seen = {}
+        finished_job = MagicMock()
+        finished_job.is_finished = True
+        finished_job.is_failed = False
+
+        def record(name, result):
+            def _inner(*args, **kwargs):
+                seen[name] = threading.current_thread().name
+                return result
+
+            return _inner
+
+        finished_job.return_value = record("return_value", {"embeddings": [[0.5]]})
+
+        with (
+            patch("app.main.Job.exists", side_effect=record("exists", True)),
+            patch("app.main.Job.fetch", side_effect=record("fetch", finished_job)),
+        ):
+            with client.websocket_connect("/ws/predict/job/thread-id/testproject") as ws:
+                msg = json.loads(ws.receive_text())
+
+        assert msg["status"] == "done"
+        assert msg["result"] == {"embeddings": [[0.5]]}
+        # asyncio.to_thread runs work on the default executor, whose threads are named
+        # "asyncio_N". Anything left inline would report the event loop's own thread.
+        for name in ("exists", "fetch", "return_value"):
+            assert name in seen, f"{name} was never called"
+            assert seen[name].startswith("asyncio_"), (
+                f"{name} ran on {seen[name]!r}, i.e. inline on the event loop"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`Preprocessing 128 images` took 10–13s per batch, entirely on the CPU with the GPU idle.
Three independent causes:

1. **The image processor was the slow variant.** `AutoImageProcessor.from_pretrained()` with
   `use_fast` unset resolves to the slow processor unless the checkpoint was saved with a
   fast one — in transformers 4.57 only `Qwen2VLImageProcessor` is force-upgraded
   (`FORCE_FAST_IMAGE_PROCESSOR`). The slow path resizes, rescales and normalizes one image
   at a time in Python/NumPy.
2. **Images were decoded serially**, one `Image.open`/`load`/`convert` at a time.
3. **Every upload was round-tripped through a temp file** so PIL could read it straight back
   off disk, despite the bytes already being in memory from the HTTP request.

## Changes

- Request the torchvision-backed fast processor; log which class actually loaded so it's
  visible at startup. `VSS_FAST_PROCESSOR=0` restores the old behaviour.
- Decode the batch on a thread pool (`VSS_DECODE_WORKERS`, default `min(8, cpu_count)`).
  PIL releases the GIL inside `load()`, so this scales with cores.
- Pass in-memory buffers instead of temp files; removes the cleanup path entirely.
- `preprocess_images()` now accepts paths **or** buffers, plus optional labels used for
  logging and the failed-image report.

## Measured

128 × 1024px crops, 2 cores — decode only, excluding the processor change:

| | time |
|---|---|
| temp-file + serial decode | 5.33s |
| in-memory + threaded decode | 1.88s (**2.8×**) |

More cores will do better. The `use_fast` change is on top of this and should be the larger
win.

